### PR TITLE
:green_heart: Fix that archive action fails if the directories do not exist

### DIFF
--- a/.github/workflows/add_archives.yml
+++ b/.github/workflows/add_archives.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # https://github.com/kannansuresh/jekyll-blog-archive-workflow/issues/7
+      # Remove when this is fixed
+      - name: Make sure the archive directories exist
+        run: |
+          mkdir -p _archives/categories
+          mkdir -p _archives/tags
+          mkdir -p _archives/years
+
       - name: Jekyll Blog Archive
         uses: kannansuresh/jekyll-blog-archive-workflow@v1.0.3
         with:


### PR DESCRIPTION
The Jekyll Blog Archive action fails when the directories are not there. 

Create these directories as a workaround for https://github.com/kannansuresh/jekyll-blog-archive-workflow/issues/7